### PR TITLE
feat(middleware): add response unifier middleware for standardized API responses

### DIFF
--- a/@types/index.ts
+++ b/@types/index.ts
@@ -1,3 +1,4 @@
+import CustomError from "@/Error/customError";
 import { IUser } from "@/Module/user/user.entity";
 
 enum EModules {
@@ -38,6 +39,33 @@ export enum EHttpStatus {
   GatewayTimeout = 504,
 }
 
+export namespace StatusCodes {
+  export enum HttpSuccess {
+    OK = 200,
+    Created = 201,
+    NoContent = 204,
+  }
+
+  export enum HttpClientError {
+    BadRequest = 400,
+    Unauthorized = 401,
+    Forbidden = 403,
+    NotFound = 404,
+    Conflict = 409,
+  }
+
+export enum HttpServerError {
+  InternalServerError = 500,
+  NotImplemented = 501,
+  BadGateway = 502,
+  ServiceUnavailable = 503,
+  GatewayTimeout = 504,
+}
+}
+
+
+type StatusCodes = typeof EHttpStatus[keyof typeof EHttpStatus];
+
 export type BodyObject = Record<string, unknown>;
 
 export type TJwtPayload = Pick<IUser, "email" | "name" | "role"> & { sub: string };  
@@ -53,13 +81,32 @@ declare global {
   }
 }
 
+export interface ApiSuccess<T = unknown> {
+  success: true,
+  data: T,
+  statusCode: StatusCodes.HttpSuccess,
+  message?: string,
+}
+
+export interface ApiFail {
+  success: false,
+  statusCode: StatusCodes.HttpClientError | StatusCodes.HttpServerError,
+  message: string,
+}
 declare global {
   namespace Express {
+
     interface Request {
       user?: {
         id: string;
         role?: "admin" | "coach" | "student";
       };
+    }
+
+    interface Response {
+      success: <T>(resPayload: ApiSuccess<T>) => this,
+      created: <T>(resPayload: ApiSuccess<T>) => this,
+      error: (resPayload: ApiFail) => this,
     }
   }
 }

--- a/Module/user/user.controller.ts
+++ b/Module/user/user.controller.ts
@@ -1,5 +1,5 @@
 import {Request, Response} from "express";
-import { BodyObject, EHttpStatus } from "@/@types/index";
+import { BodyObject, EHttpStatus, StatusCodes } from "@/@types/index";
 import userService from "./user.service";
 import { IUser } from "./user.entity";
 import { IBaseMetadata } from "@/common/repos/types";
@@ -24,7 +24,12 @@ class UserController {
 
         if(!currentInfo) return res.status(EHttpStatus.NotFound).json({error: "User not found!"});
 
-        return res.status(EHttpStatus.OK).json(currentInfo);
+        return res.status(StatusCodes.HttpSuccess.OK).success({
+            success: true,
+            data: currentInfo,
+            statusCode: StatusCodes.HttpSuccess.OK,
+            message: "User info retrieved successfully",
+        });
     }
 
     getUser(req: Request<{id: string}>, res: Response) {

--- a/middlewares/responseUnifider.middleware.ts
+++ b/middlewares/responseUnifider.middleware.ts
@@ -1,0 +1,18 @@
+import { ApiFail, ApiSuccess } from "@/@types";
+import { NextFunction, Request, Response } from "express";
+
+export const responseUnifider = (req: Request, res: Response<ApiSuccess | ApiFail>, next: NextFunction) => {
+    const success = <T>(resPayload: ApiSuccess<T>) => {
+        res.status(200).json(resPayload);
+    }
+
+    const created = <T>(resPayload: ApiSuccess<T>) => {
+        res.status(201).json(resPayload);
+    }
+
+    const error = (resPayload: ApiFail) => {
+        res.status(resPayload.statusCode).json(resPayload);
+    }
+    
+    next();
+}

--- a/server.ts
+++ b/server.ts
@@ -5,10 +5,13 @@ import {Request, Response} from "express";
 import { errorHandler } from "./Error/utils/errorHandler";
 import { authRouter } from "@/Module/auth/auth.route";
 import CourseRouter from "./Module/course/courses.route";
+import { responseUnifider } from "./middlewares/responseUnifider.middleware";
 const port = process.env.PORT;
 const app = express();
 
 app.use(express.json());
+
+app.use(responseUnifider);
 
 app.use("/api/v1/auth", authRouter);
 


### PR DESCRIPTION

Implement response unifier middleware to standardize success and error responses across the API. This includes:
- Adding new middleware to format success/error responses consistently
- Updating user controller to use new response format
- Extending Express Response type with new methods
- Adding type definitions for standardized API responses